### PR TITLE
fix spellings and typos in  03_hardware_specs.rst.txt

### DIFF
--- a/sources/02_user_guide/02_execute/04_plugin/03_hardware_specs.rst.txt
+++ b/sources/02_user_guide/02_execute/04_plugin/03_hardware_specs.rst.txt
@@ -2,11 +2,11 @@
 
 Getting information from the QPU
 ================================
-QPUs define a set of specifications, stored in an object of type :class:`~qat.core.HardwareSpecs`, which can be retrieved by :meth:`~qat.qpus.QPUHandler.get_specs`. This set of specification defines
+QPUs define a set of specifications, stored in an object of type :class:`~qat.core.HardwareSpecs`, which can be retrieved by :meth:`~qat.qpus.QPUHandler.get_specs`. This set of specifications defines
 what could be executed on the QPU, for instance:
 
  - the **number of qubits** composing the QPU
- - the **topology** of the QPU (i.e. pair of qubits on which a two qubit gate can be applied - this attribute is a graph of type :class:`~qat.core.Topology`)
+ - the **topology** of the QPU (i.e. pair of qubits on which a two-qubit gate can be applied - this attribute is a graph of type :class:`~qat.core.Topology`)
  - the **gateset** of the QPU (i.e. supported gates)
  - the **processing types** (i.e. if the QPU support *SAMPLE* measurement, *OBSERVABLE* measurement, or both)
  - the **description** of the QPU
@@ -16,8 +16,8 @@ These specifications can be used by plugins to adapt their *compilation stage*, 
 
 Creating custom specifications
 ..............................
-This sections provides an example explaning how to create custom hardware specs. In this example, will will consider a QPU capable of executing *RX*, *RZ* and *CNOT* gates. CNOT gates can only be applied
-between few pairs of qubits defined by the topology below. This QPU is assumed to support *SAMPLE* measurement
+This section provides an example explaining how to create custom hardware specs. In this example, we will consider a QPU capable of executing *RX*, *RZ* and *CNOT* gates. CNOT gates can only be applied
+between a few pairs of qubits defined by the topology below. This QPU is assumed to support *SAMPLE* measurement
 
 .. figure:: images/topology.png
     :width: 280px
@@ -25,7 +25,7 @@ between few pairs of qubits defined by the topology below. This QPU is assumed t
 
 |
 
-This topology can be created using networkx and casted into a :class:`~qat.core.Topology`:
+This topology can be created using networkx and cast into a :class:`~qat.core.Topology`:
 
 .. run-block-mem:: python hard-specs-example
 


### PR DESCRIPTION
A simple MR fixing the typos in the docs